### PR TITLE
SDK 36 update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.vitoksmile.samples.progresscentricnotifications"
-    compileSdkPreview = "Baklava"
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.vitoksmile.samples.progresscentricnotifications"
         minSdk = 35
-        targetSdkPreview = "Baklava"
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
I updated the SDK version to the stable 36. The Baklava preview was breaking the app for Android 16 Beta 3. 